### PR TITLE
Fix datetime picker so that Waves work

### DIFF
--- a/SharkEyesCore/views.py
+++ b/SharkEyesCore/views.py
@@ -14,18 +14,13 @@ def home(request):
     overlays_view_data = OverlayManager.get_next_few_days_of_tiled_overlays()
 
     datetimes = [ i.applies_at_datetime.astimezone(tz.tzlocal()).strftime('%D, %I %p') for i in overlays_view_data ]
-    unrendereddatetimes = [ i.applies_at_datetime.strftime('%D, %I %p') for i in overlays_view_data ]
-
 
     # Team 1 says: a complete hack! it just divides a list of all of the times for all the overlays by the number
     # of defs to get a singular list of overlay times
     num_defs = len(OverlayDefinition.objects.filter(is_base=True))
 
     list_of_times = datetimes[:len(datetimes)/num_defs]
-    #list_of_times = datetimes
-    print "times:"
-    for each in list_of_times:
-        print each
+
     context = {'overlays': overlays_view_data, 'defs': OverlayDefinition.objects.filter(is_base=True), 'times':list_of_times }
     return render(request, 'index.html', context)
 

--- a/pl_chop/tasks.py
+++ b/pl_chop/tasks.py
@@ -96,6 +96,11 @@ def tile_wave_watch_overlay(overlay_id):
     full_tile_dir = os.path.join(settings.MEDIA_ROOT, settings.TILE_STORAGE_DIR, overlay.tile_dir)
     vrt_path = os.path.join(settings.MEDIA_ROOT, settings.VRT_STORAGE_DIR, "{0}.vrt".format(uuid4()))
 
+
+ #translate_cmd = ("/usr/local/bin/gdal_translate -of VRT -a_srs EPSG:4326 -gcp 0 0 -129 47.499 "
+           #          "-gcp {0} 0 -123.726 47.499 -gcp {0} {1} -123.726 40.5833 {2} {3}").format(
+          #  str(width), str(height), image.path, vrt_path)
+
     #wavewatch co-ords are:
     # This grid covers a region from 41.458 to 47.508N and
 


### PR DESCRIPTION
Fixing datetime picker so that only dates where there is an SST, a currents, AND a Wave overlay are visible. This is done through Django queries in the plot/models file.